### PR TITLE
Version 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# config-serverless-babel
 # config-serverless

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackcrafters/common-serverless",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "1.1.0",
+  "version": "0.1.0",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stackcrafters/common-serverless",
   "description": "A package that provides serverless setup with babel",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "main": "src/index.js",
   "files": [
     "/src",

--- a/src/controller/controller.js
+++ b/src/controller/controller.js
@@ -1,4 +1,5 @@
 import validateRequest from '../requestValidation/requestValidation';
+import { code, messageResponse } from '../utils/http';
 
 const { debug, warn, error } = console;
 
@@ -16,7 +17,7 @@ export default (requestSchema, lambdaFunc) => async (event, context) => {
     const body = event.body && JSON.parse(event.body);
     if (process.env.REQUEST_SCHEMA && !requestSchema) {
       error(`[500] The request schema was not found for path: ${path}, schema: ${process.env.REQUEST_SCHEMA}`);
-      return response({ message: '[500] Internal Server Error' }, code.INTERNAL_SERVER_ERROR);
+      return messageResponse('[500] Internal Server Error', code.INTERNAL_SERVER_ERROR);
     }
     if (requestSchema) {
       const { valid, validationResponse } = validateRequest(requestSchema, body);
@@ -34,26 +35,6 @@ export default (requestSchema, lambdaFunc) => async (event, context) => {
   } catch (e) {
     context?.serverlessSdk?.captureError(e);
     error(`[500] Controller failed to execute with a exception for path ${path}, principal: ${principal}`, e);
-    return response({ message: '[500] Internal Server Error' }, code.INTERNAL_SERVER_ERROR);
+    return messageResponse('[500] Internal Server Error', code.INTERNAL_SERVER_ERROR);
   }
-};
-
-export const response = (body, statusCode = code.OK) => {
-  return {
-    statusCode: statusCode,
-    body: JSON.stringify(body),
-    headers: {
-      'Access-Control-Allow-Origin': '*'
-    }
-  };
-};
-
-export const code = {
-  OK: 200,
-  CREATED: 201,
-  BAD_REQUEST: 400,
-  UNAUTHORISED: 401,
-  FORBIDDEN: 403,
-  NOT_FOUND: 404,
-  INTERNAL_SERVER_ERROR: 500
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export { default as controller } from './controller/controller';
-export { default as requestValidation , makeResponseFromErrors } from './requestValidation/requestValidation';
+export { default as requestValidation, makeResponseFromErrors } from './requestValidation/requestValidation';
 export { default as defaultSchema } from './requestValidation/defaultSchema';
 export { code, response, messageResponse } from './utils/http';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export { default as controller } from './controller/controller';
-export { default as requestValidation } from './requestValidation/requestValidation';
+export { default as requestValidation , makeResponseFromErrors } from './requestValidation/requestValidation';
 export { default as defaultSchema } from './requestValidation/defaultSchema';
 export { code, response, messageResponse } from './utils/http';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { default as controller } from './controller/controller';
 export { default as requestValidation } from './requestValidation/requestValidation';
 export { default as defaultSchema } from './requestValidation/defaultSchema';
+export { code, response, messageResponse } from './utils/http';

--- a/src/requestValidation/defaultSchema.js
+++ b/src/requestValidation/defaultSchema.js
@@ -1,5 +1,1 @@
-export default {
-  default: {
-    type: 'ignore'
-  }
-};
+export default { type: 'ignore' };

--- a/src/requestValidation/requestValidation.js
+++ b/src/requestValidation/requestValidation.js
@@ -1,4 +1,4 @@
-import { code, response } from '../controller/controller';
+import { code, response } from '../utils/http';
 const isEmptyObject = (obj) => Object.entries(obj).length === 0 && obj.constructor === Object;
 
 const validateObject = (propNames, schemaNode, bodyNode) => {

--- a/src/requestValidation/requestValidation.js
+++ b/src/requestValidation/requestValidation.js
@@ -10,11 +10,22 @@ const validateObject = (propNames, schemaNode, bodyNode) => {
     return { [propNames.length > 0 ? propNames.join('.') : 'body']: 'must be of type object' };
   }
   if (bodyNode && bodyNode.constructor === Object) {
+    const schemaKeys = schemaNode.strict && schemaNode.properties && Object.keys(schemaNode.properties);
+
     return {
       /** Recursive call to each of the properties of the object */
       ...Object.entries(schemaNode.properties || {}).reduce((errors, [propName, propNode]) => {
         return merge(errors, validateNode(propNode, bodyNode[propName], propNames.concat([propName])));
       }, {}),
+
+      ...(schemaNode.strict &&
+        schemaNode.properties &&
+        Object.keys(bodyNode).reduce((acc, k) => {
+          if (!schemaKeys.includes(k)) {
+            return { ...acc, [`${[propNames.length > 0 ? `${propNames.join('.')}.` : '']}${k}`]: 'is not allowed on this object' };
+          }
+          return acc;
+        }, {})),
 
       /** Call Function if exists */
       ...(schemaNode.function && schemaNode.function(propNames.length > 0 ? propNames.join('.') : 'body', schemaNode, bodyNode))
@@ -63,7 +74,7 @@ const validateString = (propNames, schemaNode, bodyNode) => {
   }
   /** Check if String matches a pattern if pattern exists */
   if (schemaNode.pattern && !new RegExp(schemaNode.pattern).test(bodyNode)) {
-    return { [propNames.join('.')]: 'does not match pattern' };
+    return { [propNames.join('.')]: `does not match pattern${schemaNode.patternHelper ? ` (${schemaNode.patternHelper})` : ''}` };
   }
   /** Check if String matches function if function exists */
   if (schemaNode.function) {
@@ -95,7 +106,7 @@ const validateNumber = (propNames, schemaNode, bodyNode) => {
   }
   /** Check if Number matches a pattern if pattern exists */
   if (schemaNode.pattern && !new RegExp(schemaNode.pattern).test(bodyNode)) {
-    return { [propNames.join('.')]: 'does not match pattern' };
+    return { [propNames.join('.')]: `does not match pattern${schemaNode.patternHelper ? ` (${schemaNode.patternHelper})` : ''}` };
   }
   /** Check if Number is between min and max if both exists */
   if (typeof schemaNode.min === 'number' && typeof schemaNode.max === 'number') {
@@ -119,7 +130,7 @@ const validateNumber = (propNames, schemaNode, bodyNode) => {
   return {};
 };
 
-const validateNode = (schemaNode, bodyNode, propNames = []) => {
+export const validateNode = (schemaNode, bodyNode, propNames = []) => {
   switch (schemaNode.type) {
     case 'object':
       return validateObject(propNames, schemaNode, bodyNode);
@@ -140,14 +151,13 @@ const validateNode = (schemaNode, bodyNode, propNames = []) => {
 
 const merge = (object1, object2) => ({ ...object1, ...object2 });
 
-const makeResponseFromErrors = (validationErrors) => {
+export const makeResponseFromErrors = (validationErrors) => {
   console.info('[400] Validation Errors - ', JSON.stringify(validationErrors));
   return response({ message: 'Validation Errors', validationErrors }, code.BAD_REQUEST);
 };
 
-const validateRequest = (requestSchema, event) => {
+export const validateRequest = (requestSchema, body) => {
   try {
-    const body = event.body && JSON.parse(event.body);
     const validationErrors = validateNode(requestSchema, body);
     if (isEmptyObject(validationErrors)) {
       return { valid: true };
@@ -159,3 +169,4 @@ const validateRequest = (requestSchema, event) => {
 };
 
 export default validateRequest;
+

--- a/src/requestValidation/requestValidation.test.js
+++ b/src/requestValidation/requestValidation.test.js
@@ -1,27 +1,25 @@
-import validateRequest from './RequestValidation';
+import validateRequest from './requestValidation';
 
-const setupEvent = ({ principalId, pathParameters, body }) => {
-  return { requestContext: { authorizer: { principalId } }, pathParameters, body: body ? JSON.stringify(body) : body };
-};
-
-const setupSchema = ({ type, required, func, properties, pattern, ...more }) => {
+const setupSchema = ({ type, required, func, properties, pattern, patternHelper, strict, ...more }) => {
   return {
     type: type,
     ...(required && { required }),
     ...(func && { function: func }),
     ...(properties && { properties }),
     ...(pattern && { pattern }),
+    ...(patternHelper && { patternHelper }),
+    ...(strict && { strict }),
     ...more
   };
 };
 
-const setupSchemaObject = (required, func, properties) => setupSchema({ type: 'object', required, func, properties });
+const setupSchemaObject = (required, func, properties, strict) => setupSchema({ type: 'object', required, func, properties, strict });
 const setupSchemaArray = (required, func, properties) => setupSchema({ type: 'array', required, func, properties });
-const setupSchemaString = (required, pattern, func) => setupSchema({ type: 'string', required, pattern, func });
+const setupSchemaString = (required, pattern, func, patternHelper) =>
+  setupSchema({ type: 'string', required, pattern, func, patternHelper });
 const setupSchemaNumber = (required, pattern, min, max, func) => setupSchema({ type: 'number', required, pattern, func, min, max });
 const setupSchemaBoolean = (required) => setupSchema({ type: 'boolean', required });
 
-let event;
 let requestSchema;
 
 beforeEach(() => {
@@ -31,37 +29,45 @@ beforeEach(() => {
 describe('type validation for object', () => {
   describe('return valid:false - bad request', () => {
     beforeEach(() => {
-      requestSchema = setupSchemaObject(true, () => ({ body: 'function has errors' }), {
-        a: setupSchemaObject(true, false, { b: setupSchemaObject(true) })
-      });
+      requestSchema = setupSchemaObject(
+        true,
+        () => ({ body: 'function has errors' }),
+        {
+          a: setupSchemaObject(true, false, { b: setupSchemaObject(true) })
+        },
+        true
+      );
     });
     it('object - is required', async () => {
-      event = setupEvent({ body: undefined });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, undefined);
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ body: 'is required' }) })
       );
       expect(valid).toBe(false);
     });
     it('object - is of type object', async () => {
-      event = setupEvent({ body: 'a non object body' });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, 'a non object body');
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ body: 'must be of type object' }) })
       );
       expect(valid).toBe(false);
     });
     it('object - properties are recursive', async () => {
-      event = setupEvent({ body: { a: {} } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: {} });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ 'a.b': 'is required' }) })
       );
       expect(valid).toBe(false);
     });
+    it('object - strict detects additional properties', async () => {
+      const { valid, validationResponse } = await validateRequest(requestSchema, { c: {} });
+      expect(JSON.parse(validationResponse.body)).toEqual(
+        expect.objectContaining({ validationErrors: expect.objectContaining({ c: 'is not allowed on this object' }) })
+      );
+      expect(valid).toBe(false);
+    });
     it('object - function has errors', async () => {
-      event = setupEvent({ body: {} });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, {});
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ body: 'function has errors' }) })
       );
@@ -70,11 +76,14 @@ describe('type validation for object', () => {
   });
   describe('return valid:true', () => {
     beforeEach(() => {
-      event = setupEvent({ body: { a: {} } });
-      requestSchema = setupSchemaObject(true, () => ({}), { a: setupSchemaObject(true) });
+      requestSchema = setupSchemaObject(true, () => ({}), { a: setupSchemaObject(true) }, false);
     });
     it('object - has no errors', async () => {
-      const { valid } = await validateRequest(requestSchema, event);
+      const { valid } = await validateRequest(requestSchema, { a: {} });
+      expect(valid).toBe(true);
+    });
+    it('object - when not strict ignore additional properties', async () => {
+      const { valid } = await validateRequest(requestSchema, { a: {}, c: {} });
       expect(valid).toBe(true);
     });
   });
@@ -83,7 +92,6 @@ describe('type validation for object', () => {
 describe('type validation for array', () => {
   describe('return valid:false - bad request', () => {
     beforeEach(() => {
-      event = setupEvent({ body: undefined });
       requestSchema = setupSchemaArray(
         true,
         () => ({ body: 'function has errors' }),
@@ -91,31 +99,28 @@ describe('type validation for array', () => {
       );
     });
     it('array - is required', async () => {
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, undefined);
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ body: 'is required' }) })
       );
       expect(valid).toBe(false);
     });
     it('array - is of type array', async () => {
-      event = setupEvent({ body: 'a non array body' });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, 'a non array body');
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ body: 'must be of type array' }) })
       );
       expect(valid).toBe(false);
     });
     it('array - properties are recursive', async () => {
-      event = setupEvent({ body: [['']] });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, [['']]);
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ 'index-0.index-0': 'must be of type array' }) })
       );
       expect(valid).toBe(false);
     });
     it('array - function has errors', async () => {
-      event = setupEvent({ body: [] });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, []);
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ body: 'function has errors' }) })
       );
@@ -125,21 +130,19 @@ describe('type validation for array', () => {
   describe('return valid:true', () => {
     describe('required:true', () => {
       beforeEach(() => {
-        event = setupEvent({ body: [[]] });
         requestSchema = setupSchemaArray(true, () => ({}), setupSchemaArray(true));
       });
       it('array - has no errors', async () => {
-        const { valid } = await validateRequest(requestSchema, event);
+        const { valid } = await validateRequest(requestSchema, [[]]);
         expect(valid).toBe(true);
       });
     });
     describe('required:false', () => {
       beforeEach(() => {
-        event = setupEvent({ body: undefined });
         requestSchema = setupSchemaArray(false, () => ({}));
       });
       it('array - has no errors', async () => {
-        const r = await validateRequest(requestSchema, event);
+        const r = await validateRequest(requestSchema, undefined);
         expect(r.valid).toBe(true);
       });
     });
@@ -154,32 +157,38 @@ describe('type validation for string', () => {
       });
     });
     it('string - is required', async () => {
-      event = setupEvent({ body: { a: undefined } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: undefined });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'is required' }) })
       );
       expect(valid).toBe(false);
     });
     it('string - is of type string', async () => {
-      event = setupEvent({ body: { a: 1 } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 1 });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'must be of type string' }) })
       );
       expect(valid).toBe(false);
     });
     it('string - not match pattern', async () => {
-      event = setupEvent({ body: { a: 'A' } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 'A' });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'does not match pattern' }) })
       );
       expect(valid).toBe(false);
     });
+    it('string - not match pattern with patternHelper', async () => {
+      requestSchema = setupSchemaObject(true, false, {
+        a: setupSchemaString(true, '^[a-z]+$', () => ({ a: 'string function has errors' }), 'a to z only')
+      });
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 'A' });
+      expect(JSON.parse(validationResponse.body)).toEqual(
+        expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'does not match pattern (a to z only)' }) })
+      );
+      expect(valid).toBe(false);
+    });
     it('string - function has errors', async () => {
-      event = setupEvent({ body: { a: 'a' } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 'a' });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'string function has errors' }) })
       );
@@ -188,21 +197,19 @@ describe('type validation for string', () => {
   });
   describe('return valid:true', () => {
     beforeEach(() => {
-      event = setupEvent({ body: { a: 'a' } });
       requestSchema = setupSchemaObject(true, false, {
         a: setupSchemaString(true, '^[a-z]+$', () => ({}))
       });
     });
     it('string - has no errors', async () => {
-      const { valid } = await validateRequest(requestSchema, event);
+      const { valid } = await validateRequest(requestSchema, { a: 'a' });
       expect(valid).toBe(true);
     });
     it('string - not required with defined pattern', async () => {
       requestSchema = setupSchemaObject(true, false, {
         a: setupSchemaString(false, '^[a-z]+$', () => ({}))
       });
-      event = setupEvent({ body: { a: '' } });
-      const { valid } = await validateRequest(requestSchema, event);
+      const { valid } = await validateRequest(requestSchema, { a: '' });
       expect(valid).toBe(true);
     });
   });
@@ -216,62 +223,55 @@ describe('type validation for number', () => {
       });
     });
     it('number - is required', async () => {
-      event = setupEvent({ body: { a: undefined } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: undefined });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'is required' }) })
       );
       expect(valid).toBe(false);
     });
     it('number - is of type string', async () => {
-      event = setupEvent({ body: { a: '1' } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: '1' });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'must be of type number' }) })
       );
       expect(valid).toBe(false);
     });
     it('number - not match pattern', async () => {
-      event = setupEvent({ body: { a: 0 } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 0 });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'does not match pattern' }) })
       );
       expect(valid).toBe(false);
     });
     it('number - not between min and max', async () => {
-      event = setupEvent({ body: { a: 1 } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 1 });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'must be between 2 and 9' }) })
       );
       expect(valid).toBe(false);
     });
     it('number - not less than min', async () => {
-      event = setupEvent({ body: { a: 1 } });
       requestSchema = setupSchemaObject(true, false, {
         a: setupSchemaNumber(true, false, 2, undefined)
       });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 1 });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'must be greater than 2' }) })
       );
       expect(valid).toBe(false);
     });
     it('number - not greater than max', async () => {
-      event = setupEvent({ body: { a: 2 } });
       requestSchema = setupSchemaObject(true, false, {
         a: setupSchemaNumber(true, false, undefined, 1)
       });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 2 });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'must be less than 1' }) })
       );
       expect(valid).toBe(false);
     });
     it('number - function has errors', async () => {
-      event = setupEvent({ body: { a: 2 } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 2 });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'number function has errors' }) })
       );
@@ -280,13 +280,12 @@ describe('type validation for number', () => {
   });
   describe('return valid:true', () => {
     beforeEach(() => {
-      event = setupEvent({ body: { a: 1 } });
       requestSchema = setupSchemaObject(true, false, {
         a: setupSchemaNumber(true, '^[0-9]+$', 0, 9, () => ({}))
       });
     });
     it('number - has no errors', async () => {
-      const { valid } = await validateRequest(requestSchema, event);
+      const { valid } = await validateRequest(requestSchema, { a: 1 });
       expect(valid).toBe(true);
     });
   });
@@ -300,16 +299,14 @@ describe('type validation for boolean', () => {
       });
     });
     it('is missing', async () => {
-      event = setupEvent({ body: {} });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, {});
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'is required' }) })
       );
       expect(valid).toBe(false);
     });
     it('is not of type boolean', async () => {
-      event = setupEvent({ body: { a: 0 } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: 0 });
       expect(JSON.parse(validationResponse.body)).toEqual(
         expect.objectContaining({ validationErrors: expect.objectContaining({ a: 'must be of type boolean' }) })
       );
@@ -318,8 +315,7 @@ describe('type validation for boolean', () => {
   });
   describe('return valid', () => {
     it('is present', async () => {
-      event = setupEvent({ body: { a: false } });
-      const { valid, validationResponse } = await validateRequest(requestSchema, event);
+      const { valid, validationResponse } = await validateRequest(requestSchema, { a: false });
       expect(valid).toBe(true);
     });
   });

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,0 +1,29 @@
+export const response = (body, statusCode = code.OK) => {
+  return {
+    statusCode: statusCode,
+    body: JSON.stringify(body),
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    }
+  };
+};
+
+export const messageResponse = (message, statusCode = code.FORBIDDEN) => {
+  return {
+    statusCode: statusCode,
+    body: JSON.stringify({ statusCode, message }),
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    }
+  };
+};
+
+export const code = {
+  OK: 200,
+  CREATED: 201,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  INTERNAL_SERVER_ERROR: 500
+};


### PR DESCRIPTION
- Migrated to new schema approach allowing strict validation
- (BREAKING CHANGE) The controller is called by passing a exact schema to use rather than the name lookup via ENV variable.
- Body and claims are now passed down the functions to avoid having to parse JSON multiple times.
- Added http utils for code, response and messageResponse. 
- Export makeResponseFromErrors()
- Updated default schema to use new format